### PR TITLE
Add CODEOWNERS to repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# People marked here will be automatically requested for a review
+# when the code that they own is touched.
+# https://github.com/blog/2392-introducing-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @adilei @HenryJammes @nesrivastavaMS
+
+/CustomAnalytics @iMicknl @adilei @HenryJammes @nesrivastavaMS


### PR DESCRIPTION
This pull request includes an update to the `.github/CODEOWNERS` file to automatically request specific users for review when code they own is modified. This includes a wildcard pattern for all files and a specific pattern for the `/CustomAnalytics` directory.

Would be good to adapt this to the 'owner' per project.

Main change:

* <a href="diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R8">`.github/CODEOWNERS`</a>: Updated the `.github/CODEOWNERS` file to automatically request specific users for review when code they own is modified.