### PR TITLE
Fix URL spaces in conversational boosting YAML

### DIFF
--- a/DataverseIndexer/Conversational boosting.yml
+++ b/DataverseIndexer/Conversational boosting.yml
@@ -45,7 +45,7 @@ beginDialog:
                             IsBlank(Url),
                             If(
                                 Left(Name,8) = "https://", 
-                                Name,
+                                Substitute(Name, " ", "%20"),
                                 "cite:" & Id
                             ),
                             // Else use the returned URL Value.


### PR DESCRIPTION
If the original document or folder names contain spaces, the links will be broken. Therefore replace " " with "%20" in the url.