### PR TITLE
Added page redirect to sharepoint link

### DIFF
--- a/DataverseIndexer/Conversational boosting.yml
+++ b/DataverseIndexer/Conversational boosting.yml
@@ -30,10 +30,10 @@ beginDialog:
                     CountRows(Topic.Answer.Text.CitationSources) = 0, 
                     // Render the original answer
                     Topic.Answer.Text.MarkdownContent,
-                
+
                     // If there are citations, rebuild the Markdown answer entirely 
                     Topic.Answer.Text.Content & Char(10) & Char(10) & 
-                
+
                     // Concatenate citations in Markdown format
                     Concat(
                         Topic.Answer.Text.CitationSources,
@@ -51,10 +51,24 @@ beginDialog:
                             // Else use the returned URL Value.
                             Url
                         ) &
-                
+                        With(
+                  {
+                    firstPos: Find("value=", Text) + 7, // we add 7 to make up for value="
+                    lastPos: Find(">", Text, 1) // find the closing bracket
+                  },
+                  // only add "#page=<page number>" if brackets are found and document is pdf
+                    If(
+                      firstPos > 0 && lastPos > 0 && EndsWith(Lower(Name), ".pdf"),
+                      
+                      "#" & "page=" & Mid(Text, firstPos, (lastPos - firstPos) - 1),
+                      "" //add nothing if not found 
+                  )
+                )
+                &
+                        
                         // Improve file name formatting
                         " """ & 
-                
+
                         // Extract the file name, remove query if present
                         Substitute(
                             If(
@@ -64,14 +78,13 @@ beginDialog:
                             ),
                             "%20", " "
                         )
-                
+
                         &  """",
-                
+
                         // Line breaks between citations
                         Char(10) & Char(10)
                     )
                 )
-
             - kind: SendActivity
               id: sendActivity_skwikk
               activity: "{Topic.FormattedAnswer}"


### PR DESCRIPTION
This PR added the functionality to the Dataverse Indexer. It helps to redirect the user to specific page on a Citation from Sharepoint(only works for pdf). Many of my costumers wanted this, as some pdf documents were huge