### PR TITLE
RelayBot: Fix persist tokenEndpoint query params

### DIFF
--- a/RelayBotSample/BotConnector/BotService.cs
+++ b/RelayBotSample/BotConnector/BotService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
             {
                 httpRequest.Method = HttpMethod.Get;
                 UriBuilder uriBuilder = new UriBuilder(TokenEndPoint);
-                uriBuilder.Query = $"botId={BotId}&tenantId={TenantId}";
+                uriBuilder.Query += $"&botId={BotId}&tenantId={TenantId}";
                 httpRequest.RequestUri = uriBuilder.Uri;
                 using (var response = await s_httpClient.SendAsync(httpRequest))
                 {


### PR DESCRIPTION
This should be helpful for developers trying to get started with Copilot Studio Agents integration with Azure Channels with token endpoint. Without this fix, the API call to token endpoint fails due to missing required "api-version" query parameter error, which is being removed due to formation of new query string.