### PR TITLE
RelayBot: Fix warning obsolete BotFrameworkHttpAdapter

### DIFF
--- a/RelayBotSample/AdapterWithErrorHandler.cs
+++ b/RelayBotSample/AdapterWithErrorHandler.cs
@@ -2,15 +2,16 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
 {
-    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    public class AdapterWithErrorHandler : CloudAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(configuration, logger)
+        public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<CloudAdapter> logger)
+            : base(auth, logger)
         {
             OnTurnError = async (turnContext, exception) =>
             {

--- a/RelayBotSample/Controllers/BotController.cs
+++ b/RelayBotSample/Controllers/BotController.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample.Controllers
@@ -15,10 +16,10 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample.Controllers
     [ApiController]
     public class BotController : ControllerBase
     {
-        private readonly IBotFrameworkHttpAdapter Adapter;
+        private readonly CloudAdapter Adapter;
         private readonly IBot Bot;
 
-        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        public BotController(CloudAdapter adapter, IBot bot)
         {
             Adapter = adapter;
             Bot = bot;

--- a/RelayBotSample/Startup.cs
+++ b/RelayBotSample/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PowerVirtualAgents.Samples.RelayBotSample.Bots;
@@ -26,8 +27,11 @@ namespace Microsoft.PowerVirtualAgents.Samples.RelayBotSample
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
+            // Create the Bot Framework Authentication to be used with the Bot Adapter.
+            services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
             // Create the Bot Framework Adapter with error handling enabled.
-            services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
+            services.AddSingleton<CloudAdapter, AdapterWithErrorHandler>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddSingleton<IBot, RelayBot>();


### PR DESCRIPTION
Replaced obsolete "BotFrameworkHttpAdapter" with "CloudAdapter" to fix warning message while running app.